### PR TITLE
Implement functions based on fold

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -3,32 +3,35 @@ import {
   assertEquals,
   assertStrictEquals,
 } from "https://deno.land/std/testing/asserts.ts";
+import { add } from "https://deno.land/x/fae@v1.0.0/mod.ts";
 
 import { Iter } from "./mod.ts";
 
-Deno.test("Iter is iterable", () => {
+Deno.test("is iterable", () => {
   const expect = [1, 2, 3, 4];
   const got = [...new Iter(expect)];
   assertEquals(got, expect);
 });
 
-Deno.test("Iter is consumable", () => {
+Deno.test("is consumable", () => {
   const it = new Iter([1, 2, 3, 4]);
   for (const _ of it);
   const { done } = it.next();
   assert(done);
 });
 
-Deno.test("Iter.enumerate", () => {
+Deno.test("enumerate", () => {
   const arr = [1, 2, 3, 4];
   const got = [...new Iter(arr).enumerate()];
   const expect = [[0, 1], [1, 2], [2, 3], [3, 4]];
   assertEquals(got, expect);
 });
 
-Deno.test("Iter.fold", () => {
-  const arr = [1, 2, 3, 4];
-  const got = new Iter(arr).fold(0, (acc, v) => acc + v);
-  const expect = 10;
-  assertStrictEquals(got, expect);
+Deno.test("fold", () => {
+  assertStrictEquals(new Iter([1, 2, 3, 4]).fold(0, add), 10);
+  assertStrictEquals(
+    new Iter([] as number[]).fold(0, add),
+    0,
+    "expect inital value on empty iterator",
+  );
 });

--- a/mod.ts
+++ b/mod.ts
@@ -135,3 +135,5 @@ export class Iter<T> implements IterableIterator<T> {
     return init;
   }
 }
+
+type Option<T> = T | null;

--- a/mod.ts
+++ b/mod.ts
@@ -134,6 +134,50 @@ export class Iter<T> implements IterableIterator<T> {
     }
     return init;
   }
+
+  /**
+   * **fold1** is the same as **fold**, but uses the first
+   * element as the initial value for the accumulator.
+   * If the iterator is empty, it returns null, else the
+   * result of the fold
+   * 
+   * @param f
+   */
+  fold1(f: (acc: T, v: T) => T): Option<T> {
+    const { value, done } = this.next();
+    if (done) {
+      return null;
+    }
+    return this.fold(value, f);
+  }
+
+  /**
+   * **count** counts the elements in the iterator by calling
+   * **next** repeatedly until the iterator is consumed.
+   * 
+   * @returns the number of elements in the iterator
+   */
+  count(): number {
+    return this.fold(0, (acc) => acc + 1);
+  }
+
+  /**
+   * **forEach** calls the provided function for each element in
+   * the iterator, consuming it.
+   * 
+   * @param f The function to call
+   */
+  forEach(f: (value: T) => void): void {
+    this.fold<void>(undefined, (_, value) => f(value));
+  }
+
+  /**
+   * @returns the last element in the iterator, if any, consuming
+   * the iterator.
+   */
+  last(): Option<T> {
+    return this.fold<Option<T>>(null, (_, v) => v);
+  }
 }
 
 type Option<T> = T | null;


### PR DESCRIPTION
Contribute to #6

This PR implements for_each (forEach), fold_first (fold1), count, and last. It also creates a type alias for `T | null`, `Option<T>`, to resemble the Rust implementation more.