### PR TITLE
Implement try_fold and derivates

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -6,6 +6,9 @@ import {
 import { add } from "https://deno.land/x/fae@v1.0.0/mod.ts";
 
 import { Iter } from "./mod.ts";
+import { none } from "./option.ts";
+import { Result } from "./result.ts";
+import { parseIntegral } from "./util.ts";
 
 Deno.test("is iterable", () => {
   const expect = [1, 2, 3, 4];
@@ -34,4 +37,33 @@ Deno.test("fold", () => {
     0,
     "expect inital value on empty iterator",
   );
+});
+
+Deno.test("tryFold", () => {
+  const fn = (acc: number, v: string): Result<number, string> => {
+    const num = parseIntegral(v);
+    if (none(num)) {
+      return { success: false, value: v };
+    }
+    return { success: true, value: acc + num };
+  };
+
+  assertEquals(new Iter(["1", "2", "3", "4"]).tryFold(0, fn), {
+    success: true,
+    value: 10,
+  });
+  assertEquals(new Iter(["1", "2", "a", "b"]).tryFold(0, fn), {
+    success: false,
+    value: "a",
+  });
+});
+
+Deno.test("filter", () => {
+  assertEquals([...new Iter([1, 2, 3, 4]).filter((n) => n > 2)], [3, 4]);
+});
+
+Deno.test("filterMap", () => {
+  assertEquals([
+    ...new Iter(["0", "2", "a", "4", "b"]).filterMap(parseIntegral),
+  ], [0, 2, 4]);
 });

--- a/mod.ts
+++ b/mod.ts
@@ -181,3 +181,9 @@ export class Iter<T> implements IterableIterator<T> {
 }
 
 type Option<T> = T | null;
+type Success<T> = { success: true; value: T };
+type Error<E> = { success: false; value: E };
+type Result<T, E> = Success<T> | Error<E>;
+
+const Ok = <T>(value: T): Success<T> => ({ success: true, value });
+const Err = <E>(value: E): Error<E> => ({ success: false, value });

--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,8 @@
+import type { Option } from "./option.ts";
+import { some } from "./option.ts";
+import type { Result } from "./result.ts";
+import { ok } from "./result.ts";
+
 /**
  * Iter is a wrapper over ECMAScript 2015's protocol.
  * Based on the protocol defined next() method, Iter provides
@@ -80,8 +85,10 @@ export class Iter<T> implements IterableIterator<T> {
    * 
    * @example
    * const it = new Iter([1, 2, 3]);
-   * const { value, done } = it.next();
-   * // value === 1, done == false
+   * let { value, done } = it.next(); // value === 1, done == false
+   * ({ value, done } = it.next());   // value === 2, done == false
+   * ({ value, done } = it.next());   // value === 3, done == false
+   * ({ value, done } = it.next());   // typeof value === "undefined", done === true
    */
   next(): IteratorResult<T> {
     return this.iter.next();
@@ -178,12 +185,162 @@ export class Iter<T> implements IterableIterator<T> {
   last(): Option<T> {
     return this.fold<Option<T>>(null, (_, v) => v);
   }
+
+  /**
+   * **tryFold** applies the function as long as it returns successfully,
+   * producing a final, single value. Check Result's documentation to see
+   * how to use it.
+   * 
+   * This function works the same as **fold**, except that it short-circuits
+   * when an error occurs. If all the function calls succeed, the final value
+   * of the accumulator is returned, else the first error that occured is.
+   * 
+   * @example
+   * const sum = new Iter(stringArray).tryFold(0, (acc, v) => {
+   *   const num = parseInt(v, 10);
+   *   if (Number.isNaN(num)) {
+   *     return { success: false };
+   *   }
+   *   return { success: true, value: acc + num };
+   * })
+   * // see ok documentation
+   * if (ok(sum)) {
+   *   console.log(sum.value);
+   * } else {
+   *   console.log("A string was not a number!");
+   * }
+   * 
+   * @param init The inital value of the accumulator
+   * @param f The function to be applied
+   * @returns The final value of the accumulator, if the function succeeds,
+   * else the first error that occured
+   */
+  tryFold<U, E>(init: U, f: (acc: U, v: T) => Result<U, E>): Result<U, E> {
+    for (
+      let { value: v, done } = this.next();
+      !done;
+      ({ value: v, done } = this.next())
+    ) {
+      const res = f(init, v);
+      if (ok(res)) {
+        init = res.value;
+      } else {
+        return res;
+      }
+    }
+    return { success: true, value: init };
+  }
+
+  /**
+   * **tryForEach** consumes the iterator, applying the provided function
+   * to each element. If the function returns unsuccessfully, the iteration
+   * stops and the error is returned.
+   * 
+   * @param f The function to call
+   * @returns nothing, if the calls to the function succeeded on all elements,
+   * else the first error that occurred.
+   */
+  tryForEach<E>(f: (v: T) => Result<void, E>): Result<void, E> {
+    return this.tryFold<void, E>(undefined, (_, v) => f(v));
+  }
+
+  /**
+   * **find** finds the first element in the iterator that satisfies the
+   * given predicate, consuming all the previous elements.
+   * 
+   * @param p The predicate to be satisfied
+   * @returns The first element satisfying the predicate, if any
+   */
+  find(p: (v: T) => boolean): Option<T> {
+    return this.tryFold<null, T>(null, (_, value) => {
+      if (p(value)) {
+        return { success: false, value };
+      }
+      return { success: true, value: null };
+    }).value;
+  }
+
+  /**
+   * **findMap** finds the first element that after applying the function
+   * is not null, consuming all the previous elements.
+   * 
+   * @example
+   * function coolParseInt(s: string): Option<number> {
+   *   const num = parseInt(s, 10);
+   *   if (Number.isNaN(num)) {
+   *     return null;
+   *   }
+   *   return num;
+   * }
+   * 
+   * const arr = ["lol", "NaN", "2", "5"];
+   * const firstNumber = new Iter(arr).findMap(coolParseInt);
+   * // firstNumber === 2
+   * 
+   * @param f The function to apply
+   * @returns The first non-null value after the function was applied, if any
+   */
+  findMap<U>(f: (v: T) => Option<U>): Option<U> {
+    return this.tryFold<null, U>(null, (_, v) => {
+      const value = f(v);
+      if (some(value)) {
+        return { success: false, value };
+      }
+      return { success: true, value: null };
+    }).value;
+  }
+
+  /**
+   * **filter** creates an iterator that returns only the elemnts in the old
+   * iterator that satisfy the given predicate
+   * 
+   * @example
+   * const numbers = [1, 2, 3, 4, 5];
+   * const coolNumbers = [...new Iter(numbers).filter((n) => n > 2)];
+   * console.log(coolNumbers);
+   * // [ 3, 4, 5, ]
+   * 
+   * @param p The predicate to be satisfied
+   */
+  filter(p: (v: T) => boolean): Iter<T> {
+    const next = (): IteratorResult<T> => {
+      const value = this.find(p);
+      if (some(value)) {
+        return { value };
+      }
+      return { value, done: true };
+    };
+
+    return new Iter({ next });
+  }
+
+  /**
+   * **filterMap** creates an iterator that returns only the non-null elements
+   * resulted from applying the passed function to the elements of the old iterator.
+   * 
+   * @example
+   * function coolParseInt(s: string): Option<number> {
+   *   const num = parseInt(s, 10);
+   *   if (Number.isNaN(num)) {
+   *     return null;
+   *   }
+   *   return num;
+   * }
+   * const numbers = [...new Iter(["a", "b", "1", "2", "c"]).filterMap(coolParseInt)];
+   * console.log(numbers);
+   * // [ 1, 2 ]
+   * 
+   * @param f The function to be applied
+   */
+  filterMap<U>(f: (v: T) => Option<U>): Iter<U> {
+    const next = (): IteratorResult<U> => {
+      const value = this.findMap(f);
+      if (some(value)) {
+        return { value };
+      }
+      return { value, done: true };
+    };
+
+    return new Iter({ next });
+  }
 }
-
-type Option<T> = T | null;
-type Success<T> = { success: true; value: T };
-type Error<E> = { success: false; value: E };
-type Result<T, E> = Success<T> | Error<E>;
-
-const Ok = <T>(value: T): Success<T> => ({ success: true, value });
-const Err = <E>(value: E): Error<E> => ({ success: false, value });

--- a/option.ts
+++ b/option.ts
@@ -1,0 +1,20 @@
+/**
+ * Option represents a value that may or may not exist.
+ */
+export type Option<T> = T | null;
+
+/**
+ * **some** checks if the Option passed is a non-null value
+ * @param value An optional value
+ */
+export function some<T>(value: Option<T>): value is T {
+  return value !== null;
+}
+
+/**
+ * **none** checks if the Option passed is a null value
+ * @param value An optional value
+ */
+export function none<T>(value: Option<T>): value is null {
+  return value === null;
+}

--- a/result.ts
+++ b/result.ts
@@ -1,0 +1,40 @@
+type Ok<T> = { success: true; value: T };
+type Err<E> = { success: false; value: E };
+/**
+ * **Result** represents either a successful value or an error.
+ * An object is of type Result if it has 2 fields: success and value,
+ * where success is a boolean that indicates whether the value
+ * is successful or an error.
+ * 
+ * This type resembles Rust's [Result](https://doc.rust-lang.org/std/result/)
+ * and it is used 
+ * 
+ * @example
+ * 
+ * async function fetchResource(resource: string): Result<number, string> {
+ *   try {
+ *     const res = await fetch(resource);
+ *     const json: { count: number } = await res.json();
+ *     return { success: true, value: count };
+ *   } catch (e) {
+ *     return { success: false, value: e.toString() };
+ *   }
+ * }
+ */
+export type Result<T, E> = Ok<T> | Err<E>;
+/**
+ * **ok** checks if the Result passed is successful
+ * @param result A result
+ */
+
+export function ok<T, E>(result: Result<T, E>): result is Ok<T> {
+  return result.success;
+}
+
+/**
+ * **err** checks if the Result passed is an error
+ * @param result A result
+ */
+export function err<T, E>(result: Result<T, E>): result is Err<E> {
+  return !result.success;
+}

--- a/util.test.ts
+++ b/util.test.ts
@@ -1,0 +1,8 @@
+import { parseIntegral } from "./util.ts";
+import { none, some } from "./option.ts";
+import { assert } from "https://deno.land/std@0.85.0/testing/asserts.ts";
+
+Deno.test("utilities: parseIntegral", () => {
+  assert(some(parseIntegral("12345")));
+  assert(none(parseIntegral("sarmale")));
+});

--- a/util.ts
+++ b/util.ts
@@ -1,0 +1,9 @@
+import type { Option } from "./option.ts";
+
+export function parseIntegral(s: string): Option<number> {
+  const num = parseInt(s);
+  if (Number.isNaN(num)) {
+    return null;
+  }
+  return num;
+}


### PR DESCRIPTION
Contribute to #6

This PR implement the following methods:
- try_fold (tryFold)
- try_for_each (tryForEach)
- find
- find_map (findMap)
- filter
- filter_map (filterMap).

It also extracts `Result` and `Option` types into separate files, creates convenience functions for working with them, and create a new function `parseIntegral`, which is basically `parseInt` with base 10, but returns an `Option<number>`, which is `null` when parsing failed (instead of returning a `number` with `NaN` on failure).