### PR TITLE
Implement comparison functions

### DIFF
--- a/util.test.ts
+++ b/util.test.ts
@@ -1,8 +1,25 @@
-import { parseIntegral } from "./util.ts";
+import { cmpNumbers, parseIntegral } from "./util.ts";
 import { none, some } from "./option.ts";
 import { assert } from "https://deno.land/std@0.85.0/testing/asserts.ts";
 
 Deno.test("utilities: parseIntegral", () => {
   assert(some(parseIntegral("12345")));
   assert(none(parseIntegral("sarmale")));
+});
+
+Deno.test("utilities: cmpNumbers", () => {
+  {
+    const res = cmpNumbers(1, 1);
+    assert(some(res) && res === 0);
+  }
+  {
+    const res = cmpNumbers(1, 2);
+    assert(some(res) && res < 0);
+  }
+  {
+    const res = cmpNumbers(43, 21);
+    assert(some(res) && res > 0);
+  }
+  assert(none(cmpNumbers(1, NaN)));
+  assert(none(cmpNumbers(NaN, 32)));
 });

--- a/util.ts
+++ b/util.ts
@@ -7,3 +7,10 @@ export function parseIntegral(s: string): Option<number> {
   }
   return num;
 }
+
+export function cmpNumbers(lhs: number, rhs: number): Option<number> {
+  if (Number.isNaN(lhs) || Number.isNaN(rhs)) {
+    return null;
+  }
+  return lhs - rhs;
+}


### PR DESCRIPTION
Contribute to #6

This PR implements comparison functions for `Iter`:
- [cmp](https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.cmp)
- [cmp_by](https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.cmp_by) -> cmpBy
- [eq](https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.eq)
- [eq_by](https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.eq_by) -> eqBy
- [ne](https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.ne)
- [ge](https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.ge)
- [gt](https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.gt)
- [le](https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.le)
- [lt](https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.lt)
- [partial_cmp_by] -> partialCmpBy

Although Javascript doesn't have eiter `PartialEq` or `PartialOrd`, [partial_cmp_by] is implemented with a comparator that returns an `Option<number>`, to mimic Rust's trait methods. Because of the same reasons, [partial_cmp](https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.partial_cmp) is not implemented, given that there is no comparator in Javascript that returns an `Option` (`T | null`).

The lack of `Ord` and `Eq` also raise the question of the comparators used for the rest of the functions. Given that Javascript's comparison rules are finnicky and there is no operator overloading, it was decided that functions that take no comparator as parameters (`cmp`, `eq`, `ge`, `gt`, and the others alike) will use strict equality and operators `<` and `>` for comparison. When these don't suffice, library users can opt for `*By* variants and provide their custom comparators. This decision ensures that the defaults cover sufficient use cases and don't hurt performance, but if the users have special requirements (i.e. deep equality), their needs are fulfiled, too.

This PR also slightly refactors `map`, to look more like `filterMap` and `filter` in terms of arrangement. It also adds a new utility function called `cmpNumbers`, which is the equivalent of Rust's `PartialOrd` specialization on floats.

[partial_cmp_by]: https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.partial_cmp_by