### PR TITLE
Implement all and any, and make documentation example runnable

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -99,3 +99,37 @@ Deno.test("partialCmpBy", () => {
     assert(some(res) && res > 0);
   }
 });
+
+Deno.test("all", () => {
+  {
+    const iter = new Iter([1, 2, 3, 4]);
+    assert(iter.all((n) => n > 0));
+    assert(iter.next().done, "iterator shall be fully consumed");
+  }
+  {
+    const iter = new Iter([1, 2, 3, 4]);
+    assert(!iter.all((n) => n < 3));
+    const next = iter.next();
+    assert(
+      !next.done && next.value === 4,
+      "iterator shall not be fully consumed",
+    );
+  }
+});
+
+Deno.test("any", () => {
+  {
+    const iter = new Iter([1, 2, 3, 4]);
+    assert(iter.any((n) => n > 2));
+    const next = iter.next();
+    assert(
+      !next.done && next.value === 4,
+      "iterator shall not be fully consumed",
+    );
+  }
+  {
+    const iter = new Iter([1, 2, 3, 4]);
+    assert(!iter.any((n) => n < 1));
+    assert(iter.next().done, "iterator shall be fully consumed");
+  }
+});


### PR DESCRIPTION
Contribute to #6

This PR implements [all] and [any] methods, and also improves documentation by providing fully runnable examples in Deno. This will also open up the possibility to test the documentation examples, when `deno test --docs` is implemented (see denoland/deno#4716, denoland/deno#7916, and denoland/deno#8824).

[all]: https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.all
[any]: https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.any