### PR TITLE
Implement min, max, and derived methods

### DIFF
--- a/mod.bench.ts
+++ b/mod.bench.ts
@@ -1,0 +1,55 @@
+import { bench, runBenchmarks } from "https://deno.land/std/testing/bench.ts";
+
+import Iter from "./mod.ts";
+import { range } from "./util.ts";
+
+const rand = (v: number) => Math.random() * v % 100 | 0;
+
+const RUNS = 1;
+const COUNT = 1000000;
+
+bench({
+  name: "max with Iter",
+  runs: RUNS,
+  func(b) {
+    b.start();
+    const _v = new Iter(range(COUNT)).map(rand).max();
+    b.stop();
+    void _v;
+  },
+});
+
+bench({
+  name: "max with vanilla JS array methods",
+  runs: RUNS,
+  func(b) {
+    b.start();
+    const _v = [...range(COUNT)].map(rand).reduce((max, v) => {
+      if (v > max) {
+        return v;
+      }
+      return max;
+    });
+    b.stop();
+    void _v;
+  },
+});
+
+bench({
+  name: "max with for loop",
+  runs: RUNS,
+  func(b) {
+    b.start();
+    let max = 0;
+    for (let elem of range(COUNT)) {
+      elem = rand(elem);
+      if (elem > max) {
+        max = elem;
+      }
+    }
+    b.stop();
+    void max;
+  },
+});
+
+runBenchmarks();

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -133,3 +133,21 @@ Deno.test("any", () => {
     assert(iter.next().done, "iterator shall be fully consumed");
   }
 });
+
+Deno.test("max", () => {
+  assertStrictEquals(new Iter([1, 2, 3, 4]).max(), 4);
+  assertStrictEquals(new Iter([]).max(), null);
+});
+
+Deno.test("maxByKey", () => {
+  assertStrictEquals(new Iter([1, 2, 3, 4]).maxByKey((v) => -v), 1);
+});
+
+Deno.test("min", () => {
+  assertStrictEquals(new Iter([1, 2, 3, 4]).min(), 1);
+  assertStrictEquals(new Iter([]).min(), null);
+});
+
+Deno.test("minByKey", () => {
+  assertStrictEquals(new Iter([1, 2, 3, 4]).minByKey((v) => -v), 4);
+});

--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,5 @@
 import { Option, some } from "./option.ts";
 import { ok, Result } from "./result.ts";
-import { isSum } from "./util.ts";
 
 /**
  * **Comparator** represents a comparator functions.

--- a/mod.ts
+++ b/mod.ts
@@ -1,11 +1,54 @@
 import { Option, some } from "./option.ts";
 import { ok, Result } from "./result.ts";
+import { isSum } from "./util.ts";
+
+/**
+ * **Comparator** represents a comparator functions.
+ * If the return value is positive, lhs is greater than rhs.
+ * If it's negative, then lhs is less than rhs.
+ * Else lhs and rhs are equal.
+ */
+type Comparator<T, U> = (lhs: T, rhs: U) => number;
+/**
+ * PartialComparator is the same as Comparator.
+ * It returns null instead of a number when 2 elements can't
+ * be compared. Such an example would be comparing NaN to
+ * a number - this should return null.
+ */
+type PartialComparator<T, U> = (lhs: T, rhs: U) => Option<number>;
+
+/**
+ * **maxCmp** is used internally as a comparison function
+ * for Iter methods **max** and **maxByKey**. As **maxBy** 
+ * only swaps values if the return value of the function is
+ * positive (lhs is greater), this function ignores the case
+ * when lhs is less than rhs. Because of this, it is a malformed
+ * comparator otherwise, so it should not be used in any other
+ * context.
+ */
+const maxCmp = <T>(lhs: T, rhs: T): number => {
+  if (lhs > rhs) {
+    return 1;
+  }
+  return 0;
+};
+
+/**
+ * **minCmp** is the same as **maxCmp**, but returns -1 if lhs
+ * is less than rhs. 
+ */
+const minCmp = <T>(lhs: T, rhs: T): number => {
+  if (lhs < rhs) {
+    return -1;
+  }
+  return 0;
+};
 
 /**
  * **IntoIter** is the type that a value must satisfy to
  * be turned into an Iter
  */
-type IntoIter<T> = Iterable<T> | Iterator<T>;
+export type IntoIter<T> = Iterable<T> | Iterator<T>;
 
 /**
  * Iter is a wrapper over ECMAScript 2015's protocol.
@@ -104,14 +147,12 @@ export default class Iter<T> implements IterableIterator<T> {
    */
   enumerate(): Iter<[number, T]> {
     let index = 0;
-    const iter = this.iter;
+    const next = (): IteratorResult<[number, T]> => {
+      const { value, done } = this.next();
+      return { value: [index++, value], done };
+    };
 
-    return new Iter({
-      next() {
-        const { value, done } = iter.next();
-        return { value: [index++, value], done };
-      },
-    });
+    return new Iter({ next });
   }
 
   /**
@@ -401,7 +442,7 @@ export default class Iter<T> implements IterableIterator<T> {
    */
   cmpBy<U>(
     i: IntoIter<U>,
-    cmp: (lhs: T, rhs: U) => number,
+    cmp: Comparator<T, U>,
   ): number {
     const other = new Iter(i);
 
@@ -435,13 +476,13 @@ export default class Iter<T> implements IterableIterator<T> {
    */
   cmp(i: IntoIter<T>): number {
     return this.cmpBy(i, (lhs, rhs) => {
-      if (lhs === rhs) {
-        return 0;
-      }
       if (lhs < rhs) {
         return -1;
       }
-      return 1;
+      if (lhs > rhs) {
+        return 1;
+      }
+      return 0;
     });
   }
 
@@ -561,7 +602,7 @@ export default class Iter<T> implements IterableIterator<T> {
    */
   partialCmpBy<U>(
     i: IntoIter<U>,
-    cmp: (lhs: T, rhs: U) => Option<number>,
+    cmp: PartialComparator<T, U>,
   ): Option<number> {
     const other = new Iter(i);
 
@@ -610,6 +651,11 @@ export default class Iter<T> implements IterableIterator<T> {
   all(p: (v: T) => boolean): boolean {
     return this.tryFold(
       undefined,
+      // This assigns false to success when the predicate
+      // isn't satisfied, which makes tryFold end iteration.
+      // success will be true if all elements satisfy the
+      // predicate, else false, so it correctly indicates if all
+      // elements satisfy the predicate
       (_, v) => ({ success: p(v), value: undefined }),
     ).success;
   }
@@ -637,7 +683,104 @@ export default class Iter<T> implements IterableIterator<T> {
   any(p: (v: T) => boolean): boolean {
     return !this.tryFold(
       undefined,
+      // This assigns false to succes when the predicate
+      // is satisfied, which makes tryFold finish iteration.
+      // Because success will be false, but false means there
+      // is an element satisfying the predicate, the return
+      // value of tryFold is negated above.
       (_, v) => ({ success: !p(v), value: undefined }),
     ).success;
+  }
+
+  /**
+   * **maxBy** returns the element with the maximum value with
+   * respect to the specified comparison function
+   * 
+   * Returns null if the iterator is empty.
+   * 
+   * @param cmp The comparison function to use
+   */
+  maxBy(cmp: Comparator<T, T>): Option<T> {
+    return this.fold1((max, v) => {
+      if (cmp(v, max) > 0) {
+        return v;
+      }
+      return max;
+    });
+  }
+
+  /**
+   * **max** returns the maximum element in the iterator, with
+   * respect to operator `>`.
+   * 
+   * Returns null if the iterator is empty.
+   */
+  max(): Option<T> {
+    return this.maxBy(maxCmp);
+  }
+
+  /**
+   * **maxByKey** return the element that gives the maximum value
+   * from the specified function.
+   * 
+   * Returns null if the iterator is empty.
+   * 
+   * @param f The function to get the value to compare
+   * @param cmp Optional comparator, if operator `>` doesn't suffice.
+   */
+  maxByKey<U>(f: (v: T) => U, cmp: Comparator<U, U> = maxCmp): Option<T> {
+    const res = this.map<[U, T]>((v) => [f(v), v]).maxBy(([lhs], [rhs]) =>
+      cmp(lhs, rhs)
+    );
+    if (some(res)) {
+      return res[1];
+    }
+    return null;
+  }
+
+  /**
+   * **minBy** returns the minimum element in the iterator, with
+   * respect to the specified comparison function.
+   * 
+   * Returns null if the iterator is empty.
+   * 
+   * @param cmp The comparison function
+   */
+  minBy(cmp: Comparator<T, T>): Option<T> {
+    return this.fold1((min, v) => {
+      if (cmp(v, min) < 0) {
+        return v;
+      }
+      return min;
+    });
+  }
+
+  /**
+   * **min** returns the minimum element in the iterator, with
+   * respect to operator `<`.
+   * 
+   * Returns null if the iterator is empty.
+   */
+  min(): Option<T> {
+    return this.minBy(minCmp);
+  }
+
+  /**
+   * **minByKey** return the element that gives the minimum value
+   * from the specified function.
+   * 
+   * Returns null if the iterator is empty.
+   * 
+   * @param f The function to get the value to compare
+   * @param cmp Optional comparator, if operator `<` doesn't suffice.
+   */
+  minByKey<U>(f: (v: T) => U, cmp: Comparator<U, U> = minCmp): Option<T> {
+    const res = this.map<[U, T]>((v) => [f(v), v]).minBy(([lhs], [rhs]) =>
+      cmp(lhs, rhs)
+    );
+    if (some(res)) {
+      return res[1];
+    }
+    return null;
   }
 }

--- a/util.test.ts
+++ b/util.test.ts
@@ -1,6 +1,10 @@
-import { cmpNumbers, parseIntegral } from "./util.ts";
+import { cmpNumbers, parseIntegral, range } from "./util.ts";
 import { none, some } from "./option.ts";
-import { assert } from "https://deno.land/std@0.85.0/testing/asserts.ts";
+import {
+  assert,
+  assertEquals,
+  assertThrows,
+} from "https://deno.land/std@0.85.0/testing/asserts.ts";
 
 Deno.test("utilities: parseIntegral", () => {
   assert(some(parseIntegral("12345")));
@@ -22,4 +26,23 @@ Deno.test("utilities: cmpNumbers", () => {
   }
   assert(none(cmpNumbers(1, NaN)));
   assert(none(cmpNumbers(NaN, 32)));
+});
+
+Deno.test("utilities: range", () => {
+  assertEquals([...range(5)], [0, 1, 2, 3, 4]);
+  assertEquals([...range(3, 7)], [3, 4, 5, 6]);
+  assertEquals([...range(2, true)], [0, 1, 2]);
+  assertEquals([...range(2, 3, true)], [2, 3]);
+  assertEquals([...range(2, 8, 2)], [2, 4, 6]);
+  assertEquals([...range(2, 6, 2, true)], [2, 4, 6]);
+  assertThrows(
+    () => [...range(-1)],
+    Error,
+    "Invalid range: begin 0 is greater than end -1",
+  );
+  assertThrows(
+    () => [...range(5, 3)],
+    Error,
+    "Invalid range: begin 5 is greater than end 3",
+  );
 });

--- a/util.ts
+++ b/util.ts
@@ -14,3 +14,94 @@ export function cmpNumbers(lhs: number, rhs: number): Option<number> {
   }
   return lhs - rhs;
 }
+
+/**
+ * **range** returns a generator that yields numbers from 0 to len - 1.
+ * Pass `true` as the next argument to get an inclusive range.
+ * 
+ * @param len The number of elements to generate.
+ */
+export function range(len: number): IterableIterator<number>;
+export function range(stop: number, inclusive: true): IterableIterator<number>;
+/**
+ * **range** returns a generator that yields numbers from start to stop - 1.
+ * Pass `true` as the next argument to get an inclusive range.
+ * 
+ * @param start The number to start from.
+ * @param stop The number to end before.
+ */
+export function range(start: number, stop: number): IterableIterator<number>;
+/**
+ * **range** returns a generator that yields numbers from start to stop.
+ *  
+ * @param start The number to start from.
+ * @param stop The number to end at.
+ */
+export function range(
+  start: number,
+  stop: number,
+  inclusive: true,
+): IterableIterator<number>;
+/**
+ * **range** returns a generator that yields numbers in range [start, stop),
+ * iterating with the given step.
+ * Pass `true` as the next argument to get an inclusive range.
+ * 
+ * @param start The number to start at.
+ * @param stop The number to end before.
+ * @param step The iteration step.
+ */
+export function range(
+  start: number,
+  stop: number,
+  step: number,
+): IterableIterator<number>;
+/**
+ * **range** returns a generator that yields numbers in range [start, stop],
+ * iterating with the given step.
+ *
+ * @param start The number to start at.
+ * @param stop The number to end at.
+ * @param step The iteration step.
+ */
+export function range(
+  start: number,
+  stop: number,
+  step: number,
+  inclusive: true,
+): IterableIterator<number>;
+export function* range(
+  a: number,
+  b?: number | true,
+  c?: number | true,
+  d?: true,
+): IterableIterator<number> {
+  const [begin, end, step] = (() => {
+    if (typeof b === "boolean") {
+      return [0, a + 1, 1];
+    }
+    if (typeof b === "number") {
+      if (typeof c === "boolean") {
+        return [a, b + 1, 1];
+      }
+      if (typeof c === "number") {
+        if (typeof d === "boolean") {
+          return [a, b + 1, c];
+        }
+        return [a, b, c];
+      }
+      return [a, b, 1];
+    }
+    return [0, a, 1];
+  })();
+
+  if (begin > end) {
+    throw new Error(`Invalid range: begin ${begin} is greater than end ${end}`);
+  }
+
+  let i = begin;
+  while (i < end) {
+    yield i;
+    i += step;
+  }
+}


### PR DESCRIPTION
Contribute to #6

This PR implements the following methods:
- [min]
- [min_by] -> **minBy**
- [min_by_key] -> **minByKey**
- [max]
- [max_by] -> **maxBy**
- [max_by_key] -> **maxByKey**

Initially this PR was supposed to also implement [sum] and [product], but the same impediment as in PR #12 was encountered: the lack of traits, thereof the lack of Rust's [Sum] and [Product], combined with Typescripts [lack of generic specialization][1], make the implementation of these methods in a type-safe, generic manner with no runtime implications impossible. Library users can use `fold` for this:

```js
const arr = [1, 2, 3, 4];
const sum = new Iter(arr).fold(0, (acc, v) => acc + v);
const product = new Iter(arr).fold(1, (acc, v) => acc + v);
```

These are the [implementations][2] of the methods in Rust's standard library, anyway. The only problem with this is that it sacrifices readability and conciseness: for sure, users would prefer `iter.sum()`. Because of this, `sum` and `product` won't be marked as done, but left open to implement.

This PR also adds some benchmarks for the `max` method, to compare it with other ways you would get the maximum of an iterable in Javascript, and also a Python-like `range` generator as an utility that is used for the benchmarks. 

[1]: https://stackoverflow.com/questions/56138822/typescript-generic-specialization
[2]: https://doc.rust-lang.org/nightly/src/core/iter/traits/accum.rs.html#41-79

[min]: https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.min
[min_by]: https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.min_by
[min_by_key]: https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.min_by_key
[max]: https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.max
[max_by]: https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.max_by
[max_by_key]: https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.max_by_key
[sum]: https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.sum
[product]: https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.product
[Sum]: https://doc.rust-lang.org/nightly/std/iter/trait.Sum.html
[Product]: https://doc.rust-lang.org/nightly/std/iter/trait.Product.html