### PR TITLE
Implement zip

### DIFF
--- a/mod.bench.ts
+++ b/mod.bench.ts
@@ -1,11 +1,14 @@
 import { bench, runBenchmarks } from "https://deno.land/std/testing/bench.ts";
 
 import Iter from "./mod.ts";
-import { range } from "./util.ts";
+import { parseIntegral, range } from "./util.ts";
 
 const rand = (v: number) => Math.random() * v % 100 | 0;
 
-const RUNS = 1;
+const RUNS = parseIntegral(Deno.args[0]) ?? (() => {
+  throw new Error("Run count unspecified or invalid");
+})();
+const ONLY = new RegExp(Deno.args[1]);
 const COUNT = 1000000;
 
 bench({
@@ -52,4 +55,14 @@ bench({
   },
 });
 
-runBenchmarks();
+bench({
+  name: "enumerate",
+  runs: RUNS,
+  func(b) {
+    b.start();
+    for (const _ of new Iter(range(COUNT)).enumerate());
+    b.stop();
+  },
+});
+
+runBenchmarks({ only: ONLY });

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -8,7 +8,7 @@ import { add } from "https://deno.land/x/fae@v1.0.0/mod.ts";
 import Iter from "./mod.ts";
 import { none, some } from "./option.ts";
 import { Result } from "./result.ts";
-import { cmpNumbers, parseIntegral } from "./util.ts";
+import { cmpNumbers, parseIntegral, range } from "./util.ts";
 
 Deno.test("is iterable", () => {
   const expect = [1, 2, 3, 4];
@@ -150,4 +150,9 @@ Deno.test("min", () => {
 
 Deno.test("minByKey", () => {
   assertStrictEquals(new Iter([1, 2, 3, 4]).minByKey((v) => -v), 4);
+});
+
+Deno.test("zip", () => {
+  const a = [1, 2, 3, 4].reverse();
+  assertEquals([...new Iter(a).zip(range())], [[4, 0], [3, 1], [2, 2], [1, 3]]);
 });

--- a/util.ts
+++ b/util.ts
@@ -1,4 +1,4 @@
-import type { Option } from "./option.ts";
+import { Option, some } from "./option.ts";
 
 export function parseIntegral(s: string): Option<number> {
   const num = parseInt(s);
@@ -15,6 +15,10 @@ export function cmpNumbers(lhs: number, rhs: number): Option<number> {
   return lhs - rhs;
 }
 
+/**
+ * **range** returns a generator that yields number starting from 0, indefinitely.
+ */
+export function range(): IterableIterator<number>;
 /**
  * **range** returns a generator that yields numbers from 0 to len - 1.
  * Pass `true` as the next argument to get an inclusive range.
@@ -71,37 +75,51 @@ export function range(
   inclusive: true,
 ): IterableIterator<number>;
 export function* range(
-  a: number,
+  a?: number,
   b?: number | true,
   c?: number | true,
   d?: true,
 ): IterableIterator<number> {
-  const [begin, end, step] = (() => {
-    if (typeof b === "boolean") {
-      return [0, a + 1, 1];
-    }
-    if (typeof b === "number") {
-      if (typeof c === "boolean") {
-        return [a, b + 1, 1];
+  const params = (() => {
+    if (typeof a === "number") {
+      if (typeof b === "boolean") {
+        return [0, a + 1, 1];
       }
-      if (typeof c === "number") {
-        if (typeof d === "boolean") {
-          return [a, b + 1, c];
+      if (typeof b === "number") {
+        if (typeof c === "boolean") {
+          return [a, b + 1, 1];
         }
-        return [a, b, c];
+        if (typeof c === "number") {
+          if (typeof d === "boolean") {
+            return [a, b + 1, c];
+          }
+          return [a, b, c];
+        }
+        return [a, b, 1];
       }
-      return [a, b, 1];
+      return [0, a, 1];
     }
-    return [0, a, 1];
+    return null;
   })();
 
-  if (begin > end) {
-    throw new Error(`Invalid range: begin ${begin} is greater than end ${end}`);
-  }
+  if (some(params)) {
+    const [begin, end, step] = params;
 
-  let i = begin;
-  while (i < end) {
-    yield i;
-    i += step;
+    if (begin > end) {
+      throw new Error(
+        `Invalid range: begin ${begin} is greater than end ${end}`,
+      );
+    }
+
+    let i = begin;
+    while (i < end) {
+      yield i;
+      i += step;
+    }
+  } else {
+    let i = 0;
+    while (true) {
+      yield i++;
+    }
   }
 }


### PR DESCRIPTION
Contribute to #6

This PR implements the [zip] iterator method.

It also adds a range overload to generate infinite ranges and makes the benchmark customizable, by being able to specify through command line arguments the benchmarks to run and the times they're run.